### PR TITLE
feat: 도시 카드 좋아요/싫어요 버튼 레이아웃 개선

### DIFF
--- a/components/city-card.tsx
+++ b/components/city-card.tsx
@@ -132,7 +132,7 @@ export default function CityCard({ city }: CityCardProps) {
             </div>
 
             {/* Like/Dislike Buttons */}
-            <div className="flex items-center gap-3">
+            <div className="flex items-center justify-between">
               <button
                 onClick={handleLikeClick}
                 className={cn(
@@ -163,16 +163,16 @@ export default function CityCard({ city }: CityCardProps) {
                     : "bg-slate-700/30 border border-gray-600/20 hover:bg-slate-700/50"
                 )}
               >
-                <ThumbsDown className={cn(
-                  "h-4 w-4",
-                  disliked ? "text-red-500" : "text-gray-400"
-                )} />
                 <span className={cn(
                   "text-sm font-medium",
                   disliked ? "text-red-400" : "text-gray-400"
                 )}>
                   {dislikeCount}
                 </span>
+                <ThumbsDown className={cn(
+                  "h-4 w-4",
+                  disliked ? "text-red-500" : "text-gray-400"
+                )} />
               </button>
             </div>
           </div>


### PR DESCRIPTION
## 변경 사항

### 버튼 레이아웃
- 좋아요 버튼을 왼쪽으로 정렬
- 싫어요 버튼을 오른쪽으로 정렬
- 컨테이너를 `gap-3` → `justify-between`으로 변경

### 버튼 내부 구조
- 좋아요 버튼: [👍 아이콘][숫자] (유지)
- 싫어요 버튼: [숫자][👎 아이콘] (순서 변경)

### 최종 레이아웃
```
[👍][123] ←──────────────→ [456][👎]
 왼쪽                          오른쪽
```

## 파일 변경
- components/city-card.tsx (135-177번 줄)

## 검증
- ✅ TypeScript 컴파일: 통과
- ✅ 개발 서버 정상 실행

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)